### PR TITLE
sync .gitignore file with godotsteam repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,35 @@ sdk/*
 
 # Doxygen
 doxygen/
+
+
+# Files built by Visual Studio
+*_i.c
+*_p.c
+*_h.h
+*.ilk
+*.meta
+*.obj
+*.iobj
+*.pch
+*.pdb
+*.ipdb
+*.pgc
+*.pgd
+*.rsp
+*.sbr
+*.tlb
+*.tli
+*.tlh
+*.tmp
+*.tmp_proj
+*_wpftmp.csproj
+*.log
+*.tlog
+*.vspscc
+*.vssscc
+.builds
+*.pidb
+*.svclog
+*.scc
+


### PR DESCRIPTION
Synchronise .gitignore file to exclude compile objects generated on windows platforms. It is now equivalent to the version on the godotsteam repository.